### PR TITLE
Make `Header` Sticky

### DIFF
--- a/src/components/common/layout/header/index.tsx
+++ b/src/components/common/layout/header/index.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 
 const Header = () => (
-    <header className="fixed top-0 z-50 flex h-16 w-full items-center bg-black/25 px-4 backdrop-blur-xl backdrop-filter">
+    <header className="sticky top-0 z-50 flex h-16 w-full items-center bg-black/25 px-4 backdrop-blur-xl backdrop-filter">
         <Image
             src="/logo.svg"
             alt="Solana Logo"

--- a/src/components/explorer-page/featured-section/index.tsx
+++ b/src/components/explorer-page/featured-section/index.tsx
@@ -3,7 +3,7 @@ import FeaturedBountyCard from './featured-bounty-card';
 const FeaturedSection = () => (
     <section
         title="featured"
-        className="mt-24 w-full bg-gradient-to-tr from-primary to-secondary p-5 sm:p-8 md:px-16 lg:px-32 lg:py-16 xl:px-48 xl:py-20"
+        className="w-full bg-gradient-to-tr from-primary to-secondary p-5 sm:p-8 md:px-16 lg:px-32 lg:py-16 xl:px-48 xl:py-20"
     >
         <div className="flex w-full flex-row gap-5">
             <FeaturedBountyCard />

--- a/src/components/home-page/hero-section/index.tsx
+++ b/src/components/home-page/hero-section/index.tsx
@@ -1,24 +1,30 @@
 import Button from 'components/common/button';
 import Image from 'next/image';
+import cn from 'utils';
+
+const height = 'h-[calc(100vh_-_theme(space.20)_-_theme(space.12))]';
 
 const HeroSection = () => (
     <section
         title="hero"
-        className="relative flex flex-col h-screen w-screen items-center justify-center sm:flex-row sm:justify-start bg-black"
+        className={cn(
+            'relative flex w-screen flex-col items-center justify-center bg-black sm:flex-row sm:justify-start',
+            height,
+        )}
     >
         <div
-            className="absolute -left-3/4 z-0 h-screen w-screen"
+            className={cn('absolute -left-3/4 z-0 w-screen', height)}
             style={{
                 background:
                     'radial-gradient(50% 50% at 50% 50%, rgb(106, 108, 253) 0%, rgba(0, 0, 0, 0) 100%)',
             }}
-        ></div>
+        />
         <div
             style={{
                 background:
                     'radial-gradient(45.5% 47.88% at 45% 50.47%, rgb(255, 0, 199) 0%, rgba(0, 0, 0, 0) 100%)',
             }}
-            className="relative top-32 z-0 w-screen sm:absolute sm:top-0 sm:right-0 sm:h-screen sm:w-1/2"
+            className={`relative top-32 z-0 w-screen sm:absolute sm:top-0 sm:right-0 sm:${height} sm:w-1/2`}
         >
             <Image src="/hero.svg" alt="hero background" layout="fill" />
             <img className="invisible" src="/hero.svg" alt="placeholder"></img>


### PR DESCRIPTION
# Make `Header` Sticky

## Description

Updated the `position` attribute of the `Header` component to `sticky` to avoid issues caused by `position: fixed`. Now, all children of `Layout` will display correctly, without the need to add extra margin to individual sections.

## Screenshots

<img width="1552" alt="Screen Shot 2022-07-04 at 12 38 26" src="https://user-images.githubusercontent.com/36577958/177199449-7967c046-2405-4b89-97f1-91c04e0a711c.png">

<img width="612" alt="Screen Shot 2022-07-04 at 12 38 35" src="https://user-images.githubusercontent.com/36577958/177199473-7384ccf7-55eb-42be-9f10-b9ef5b94e075.png">

<img width="1552" alt="Screen Shot 2022-07-04 at 12 40 30" src="https://user-images.githubusercontent.com/36577958/177199677-2cf677c6-5aa9-4c42-a1cb-7838cd6f1b1d.png">

