### PR TITLE
Add `OpenBounties` to Explorer and Profile Pages

### DIFF
--- a/src/components/common/filter-section/index.tsx
+++ b/src/components/common/filter-section/index.tsx
@@ -1,15 +1,14 @@
 import {
     MdExpandMore,
-    MdSort,
     MdOutlineCategory,
     MdOutlineSearch,
+    MdSort,
 } from 'react-icons/md';
 
 const FilterPart = () => (
-    <div className=" px-4 md:px-16 lg:px-32 xl:px-48">
-
-        <div className=" flex  gap-3  text-white">
-            <div className="flex max-h-48  w-2/3 max-w-full   rounded-3xl border  bg-base/75 p-2 text-white  ">
+    <div>
+        <div className="flex gap-3 text-white">
+            <div className="flex max-h-48  w-2/3 max-w-full rounded-3xl border bg-base/75 p-2 text-white">
                 <div className="flex w-full justify-between">
                     <div className="flex w-1/2  justify-between">
                         <div className="flex gap-1 pl-8">
@@ -40,13 +39,13 @@ const FilterPart = () => (
                         placeholder="Search for bounties"
                         className="uppercase  opacity-50 bg-base/75 "
                     /> */}
-                    <p className=" uppercase text-base-content opacity-50">
+                    <p className="uppercase text-base-content opacity-50">
                         Search for bounties
                     </p>
                 </div>
             </div>
         </div>
-        <div className="flex justify-between  pt-4 text-base-content">
+        <div className="flex justify-between pt-4 text-base-content">
             <p className="m-auto uppercase">Basics</p>
             <p className="m-auto uppercase">Rewards</p>
             <p className="m-auto uppercase">Tags</p>

--- a/src/components/common/layout/header/index.tsx
+++ b/src/components/common/layout/header/index.tsx
@@ -1,11 +1,11 @@
 import Button from 'components/common/button';
-import SearchBar from 'components/common/search-bar';
 // import Image from 'components/common/image';
 import Image from 'next/image';
 import Link from 'next/link';
+import SearchBar from 'components/common/search-bar';
 
 const Header = () => (
-    <header className="flex flex-row justify-between fixed top-0 z-50 w-full h-20 items-center bg-black/25 px-6 backdrop-blur-xl backdrop-filter">
+    <header className="sticky top-0 z-50 flex h-20 w-full flex-row items-center justify-between bg-black/25 px-6 backdrop-blur-xl backdrop-filter">
         <div className="flex gap-10">
             <Image
                 src="/logo.svg"
@@ -21,12 +21,12 @@ const Header = () => (
             </div>
         </div>
 
-        <div className="flex-row gap-5 h-fit hidden sm:flex">
+        <div className="hidden h-fit flex-row gap-5 sm:flex">
             <SearchBar />
 
             <div className="w-px bg-white" />
 
-            <div className="flex-row gap-3 hidden md:flex">
+            <div className="hidden flex-row gap-3 md:flex">
                 <Button text="Log in" variant="transparent" />
                 <Button text="Sign up" variant="orange" />
             </div>

--- a/src/components/common/main-bounty-card/index.tsx
+++ b/src/components/common/main-bounty-card/index.tsx
@@ -11,45 +11,43 @@ type CardProps = {
 };
 
 const BountyCard = ({ imageSource, bountyTitle, bountyPrize }: CardProps) => (
-    <div className=" px-4 md:px-16 lg:px-32 xl:px-48">
-        <div className="align-center flex h-20 w-full gap-3 rounded-lg border bg-base px-2 text-white">
-            <div className="my-2 mr-2">
-                <img
-                    className="aspect-square h-full rounded-md"
-                    src={imageSource}
-                    alt="Bounty Logo"
-                />
-            </div>
-            <div className="align-center flex flex-grow justify-between">
-                <div className="my-auto">
-                    <h2 className="text-3xl  font-semibold">{bountyTitle}</h2>
-                </div>
-                <div className="my-auto ">
-                    <p className="font-small uppercase text-base-content opacity-50">
-                        Up to
-                    </p>
-                    <h2 className="text-2xl font-semibold text-base-content">
-                        {bountyPrize}
-                    </h2>
-                </div>
-                <div className="mt-3 flex max-h-5 flex-col gap-2">
-                    <div className="flex gap-2">
-                        <Chip
-                            highlightValue="Jun 4"
-                            value="Placed"
-                            reversed={true}
-                        />
-                        <Chip highlightValue="4" value="Participants" />
-                    </div>
-                    <div className="flex gap-2">
-                        <Chip value="Category" />
-                        <Chip value="Github tag" />
-                    </div>
-                </div>
-            </div>
+    <div className="align-center flex h-20 w-full gap-3 rounded-lg border bg-base px-2 text-white">
+        <div className="my-2 mr-2">
+            <img
+                className="aspect-square h-full rounded-md"
+                src={imageSource}
+                alt="Bounty Logo"
+            />
+        </div>
+        <div className="align-center flex flex-grow justify-between">
             <div className="my-auto">
-                <MdNavigateNext size={28}/>
+                <h2 className="text-3xl  font-semibold">{bountyTitle}</h2>
             </div>
+            <div className="my-auto ">
+                <p className="font-small uppercase text-base-content opacity-50">
+                    Up to
+                </p>
+                <h2 className="text-2xl font-semibold text-base-content">
+                    {bountyPrize}
+                </h2>
+            </div>
+            <div className="mt-3 flex max-h-5 flex-col gap-2">
+                <div className="flex gap-2">
+                    <Chip
+                        highlightValue="Jun 4"
+                        value="Placed"
+                        reversed={true}
+                    />
+                    <Chip highlightValue="4" value="Participants" />
+                </div>
+                <div className="flex gap-2">
+                    <Chip value="Category" />
+                    <Chip value="Github tag" />
+                </div>
+            </div>
+        </div>
+        <div className="my-auto">
+            <MdNavigateNext size={28} />
         </div>
     </div>
 );

--- a/src/pages/[username].tsx
+++ b/src/pages/[username].tsx
@@ -1,10 +1,15 @@
 import Hero from 'components/profile-page/hero';
 import { NextPage } from 'next';
+import OpenBounties from 'components/explorer-page/open-bounties-section';
 
 const Profile: NextPage = () => (
     <div className="mt-8">
-        <div className="px-4 sm:px-8 md:gap-32 md:px-16 lg:px-32 xl:px-48">
+        <div className="flex flex-col gap-16 px-4 sm:px-8 md:px-16 lg:px-32 xl:px-48">
             <Hero />
+            <div className="flex flex-col gap-7">
+                <h2 className="text-2xl font-medium text-white">My Bounties</h2>
+                <OpenBounties />
+            </div>
         </div>
     </div>
 );

--- a/src/pages/explorer.tsx
+++ b/src/pages/explorer.tsx
@@ -1,10 +1,22 @@
 import FeaturedSection from 'components/explorer-page/featured-section';
 import { NextPage } from 'next';
+import OpenBounties from 'components/explorer-page/open-bounties-section';
 
 const Explorer: NextPage = () => (
-    <>
+    <div className="flex flex-col gap-12">
         <FeaturedSection />
-    </>
+        <div className="flex flex-col gap-0">
+            <div className="flex w-full flex-col gap-7 px-5 sm:px-8 md:px-16 lg:px-32 xl:px-48">
+                <p className="text-sm font-light uppercase text-white">
+                    Browse
+                </p>
+                <h2 className="text-4xl font-medium text-white md:text-6xl">
+                    Open Bounties
+                </h2>
+                <OpenBounties />
+            </div>
+        </div>
+    </div>
 );
 
 export default Explorer;


### PR DESCRIPTION
# Add `OpenBounties` to Explorer and Profile Pages

## Description

- Added the `OpenBounties` section to both pages as shown in the Figma. I had to modify the `BountyCard` and `FilterPart` components to make them reusable.
- Made the `Header` sticky again as it was probably overwritten by accident.

## Screenshots

![screencapture-localhost-3000-explorer-2022-07-06-12_34_20](https://user-images.githubusercontent.com/36577958/177609990-364f58c9-13aa-490b-addb-774a3ddc937f.png)

![screencapture-localhost-3000-johndoe-2022-07-06-12_34_42](https://user-images.githubusercontent.com/36577958/177609974-810a8eb7-2c8f-4ff7-868b-e5b070b3a466.png)