### PR TITLE
Fixed Header

### DIFF
--- a/src/components/common/layout/header/index.tsx
+++ b/src/components/common/layout/header/index.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import SearchBar from 'components/common/search-bar';
 
 const Header = () => (
-    <header className="sticky top-0 z-50 flex h-20 w-full flex-row items-center justify-between bg-black/25 px-6 backdrop-blur-xl backdrop-filter">
+    <header className="fixed top-0 z-50 flex h-20 w-full flex-row items-center justify-between bg-black/25 px-6 backdrop-blur-xl backdrop-filter">
         <div className="flex gap-10">
             <Image
                 src="/logo.svg"


### PR DESCRIPTION
#  Overview
Change `Header` display from `sticky` to `fixed` to achieve better visual behavior for the `Hero` section

# ScreenShots
## Before
<img width="1261" alt="Screenshot 2022-07-12 105710" src="https://user-images.githubusercontent.com/73449575/178562322-df553b4a-31a6-4f41-a12b-e5ad754d8759.png">

## After
<img width="1268" alt="Screenshot 2022-07-12 105638" src="https://user-images.githubusercontent.com/73449575/178562387-8d36637a-b63d-46aa-9b9b-f5ace0764de5.png">

