### PR TITLE
Make text in `BountyCard` consistent (Make text color of `BountyCard` labels consistent. #70).

### DIFF
--- a/src/components/common/chip/index.tsx
+++ b/src/components/common/chip/index.tsx
@@ -37,7 +37,7 @@ const Chip = ({ className, highlightValue, value, reversed }: ChipProps) => (
                 </span>
             )}
             {value && (
-                <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-white/50">
+                <span className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-secondary">
                     {' '}
                     {value}{' '}
                 </span>

--- a/src/components/explorer-page/bounty-card/index.tsx
+++ b/src/components/explorer-page/bounty-card/index.tsx
@@ -62,7 +62,7 @@ const FeaturedBountyCard = ({
                 <Text
                     variant="label"
                     className={cn(
-                        'inline opacity-50',
+                        'inline text-secondary',
                         responsive && '2lg:hidden',
                     )}
                 >
@@ -79,7 +79,7 @@ const FeaturedBountyCard = ({
                 <Text
                     variant="label"
                     className={cn(
-                        'pacity-50 inline w-fit',
+                        'text-secondary inline w-fit',
                         responsive && '2lg:hidden',
                     )}
                 >


### PR DESCRIPTION
# Overview

Make text in `BountyCard`-component more consistent (use custom `text-secondary` property).

## Features

- Permanently change text color of `Chip`-component to match.

## Fixes

- Close #70.