### PR TITLE
Redesign `Header`.

### DIFF
--- a/src/components/common/button/index.tsx
+++ b/src/components/common/button/index.tsx
@@ -1,3 +1,4 @@
+import React, { Children } from 'react';
 import Text from '../text';
 import { cn } from 'utils';
 
@@ -7,7 +8,8 @@ import { cn } from 'utils';
 type ButtonProps = {
     type?: 'button' | 'submit' | 'reset';
     variant?: string;
-    text: string;
+    text?: string;
+    children?: React.ReactNode;
 };
 
 /**
@@ -30,15 +32,18 @@ const Button = ({
     type = 'button',
     variant = 'black',
     text: value,
+    children
 }: ButtonProps) => (
     <button
         className={cn(
             variants[variant],
-            'flex h-fit w-fit items-center justify-center rounded-full border px-5 py-3 transition-all hover:-translate-y-[0.2rem] hover:bg-white hover:text-black active:translate-y-[0.05rem] active:scale-95',
+            'flex items-center justify-center gap-3 w-fit h-fit max-h-full rounded-full border transition-all hover:-translate-y-[0.2rem] hover:bg-white hover:!text-black active:translate-y-[0.05rem] active:scale-95',
+            value || (React.Children.count(children) > 1) ? 'px-5 py-3' : 'p-3 aspect-square',
         )}
         type={type}
     >
         {value && <Text variant="input">{value}</Text>}
+        {children}
     </button>
 );
 

--- a/src/components/common/layout/header/index.tsx
+++ b/src/components/common/layout/header/index.tsx
@@ -1,11 +1,15 @@
 import Button from 'components/common/button';
 // import Image from 'components/common/image';
 import Image from 'next/image';
+import Text from 'components/common/text';
 import Link from 'next/link';
 import SearchBar from 'components/common/search-bar';
 import SideNavigation from './side-navigation';
+import { useState } from 'react';
+import { cn } from 'utils';
 
 import { MdMenu } from 'react-icons/md';
+import NavElement from './nav-element';
 
 const Header = () => (
     <header className="sticky top-0 z-50 flex h-20 w-full flex-row items-center justify-between bg-black/25 px-6 backdrop-blur-xl backdrop-filter border-b-1.5 border-b-line">
@@ -18,13 +22,10 @@ const Header = () => (
         />
 
         <div className="hidden h-fit flex-row items-center gap-5 text-white md:flex">
-            <div className="flex flex-row gap-3">
-                <Link href="./">
-                    Home 
-                </Link>
-                <Link href="./explorer"> 
-                    Explorer 
-                </Link>
+            <div className="flex flex-row gap-7">
+                {/* TODO Add `TabbedLayout? */}
+                <NavElement label="home" href="/" />
+                <NavElement label="explorer" href="/explorer" />
             </div>
 
             <div className="w-px h-8 bg-line" />
@@ -34,8 +35,7 @@ const Header = () => (
             <div className="w-px h-8 bg-line" />
 
             <div className="flex flex-row gap-3">
-                <Button text="Log in" variant="transparent" />
-                <Button text="Sign up" variant="orange" />
+                <Button text="Log in / Sign up" variant="orange" />
             </div>
         </div>
 

--- a/src/components/common/layout/header/index.tsx
+++ b/src/components/common/layout/header/index.tsx
@@ -3,37 +3,44 @@ import Button from 'components/common/button';
 import Image from 'next/image';
 import Link from 'next/link';
 import SearchBar from 'components/common/search-bar';
+import { MdMenu } from 'react-icons/md';
 
 const Header = () => (
-    <header className="sticky top-0 z-50 flex h-20 w-full flex-row items-center justify-between bg-black/25 px-6 backdrop-blur-xl backdrop-filter">
-        <div className="flex gap-10">
-            <Image
-                src="/logo.svg"
-                alt="logo"
-                width={175}
-                height={27}
-                // priority
-            />
+    <header className="sticky top-0 z-50 flex h-20 w-full flex-row items-center justify-between bg-black/25 px-6 backdrop-blur-xl backdrop-filter border-b-1.5 border-b-line">
+        <Image
+            src="/logo.svg"
+            alt="logo"
+            width={175}
+            height={27}
+            // priority
+        />
 
-            <div className="flex flex-row gap-3 text-white">
-                <Link href="./"> Home </Link>
-                <Link href="./explorer"> Explorer </Link>
+        <div className="hidden h-fit flex-row items-center gap-5 text-white md:flex">
+            <div className="flex flex-row gap-3">
+                <Link href="./">
+                    Home 
+                </Link>
+                <Link href="./explorer"> 
+                    Explorer 
+                </Link>
             </div>
-        </div>
 
-        <div className="hidden h-fit flex-row gap-5 sm:flex">
+            <div className="w-px h-8 bg-line" />
+
             <SearchBar />
 
-            <div className="w-px bg-white" />
+            <div className="w-px h-8 bg-line" />
 
-            <div className="hidden flex-row gap-3 md:flex">
+            <div className="flex flex-row gap-3">
                 <Button text="Log in" variant="transparent" />
                 <Button text="Sign up" variant="orange" />
             </div>
         </div>
 
         <div className="inline md:hidden">
-            <Button text="☰" variant="transparent" />
+            <Button  variant="transparent">
+                <MdMenu className="h-4 aspect-square" />
+            </Button>
         </div>
     </header>
 );

--- a/src/components/common/layout/header/nav-element/index.tsx
+++ b/src/components/common/layout/header/nav-element/index.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable @typescript-eslint/ban-types */
+import Text from 'components/common/text';
+import Link from 'next/link';
+import { cn } from 'utils';
+import { useRouter } from "next/router";
+
+/**
+ * Properties for an interactable navigation element.
+ */
+ type NavElementProps = {
+    label: string;
+    href: string;
+};
+
+const NavElement = ({ label, href }:NavElementProps) => { 
+    const router = useRouter();
+    const isActive = href === router.asPath;
+
+    return (
+        <Link href={href} passHref> 
+            <a 
+                className={cn(
+                    "h-20 flex flex-col justify-center",
+                    isActive && "border-b-3 border-b-primary"
+                )}
+            >
+                <Text 
+                    variant="nav-heading" 
+                    className={cn(
+                        "capitalize",
+                        isActive && "mt-1"
+                    )}
+                > 
+                    {label} 
+                </Text>
+            </a>
+        </Link>
+    );
+};
+
+export default NavElement;

--- a/src/components/common/layout/header/side-navigation/index.tsx
+++ b/src/components/common/layout/header/side-navigation/index.tsx
@@ -3,20 +3,10 @@ import Button from 'components/common/button';
 import Image from 'next/image';
 import Link from 'next/link';
 import SearchBar from 'components/common/search-bar';
-import SideNavigation from './side-navigation';
-
 import { MdMenu } from 'react-icons/md';
 
-const Header = () => (
-    <header className="sticky top-0 z-50 flex h-20 w-full flex-row items-center justify-between bg-black/25 px-6 backdrop-blur-xl backdrop-filter border-b-1.5 border-b-line">
-        <Image
-            src="/logo.svg"
-            alt="logo"
-            width={175}
-            height={27}
-            // priority
-        />
-
+const SideNavigation = () => (
+    <div className="fixed top-0 z-50 flex h-screen w-1/3 flex-row items-center justify-between bg-black/25 px-6 backdrop-blur-xl backdrop-filter border-b-1.5 border-b-line">
         <div className="hidden h-fit flex-row items-center gap-5 text-white md:flex">
             <div className="flex flex-row gap-3">
                 <Link href="./">
@@ -44,7 +34,7 @@ const Header = () => (
                 <MdMenu className="h-4 aspect-square" />
             </Button>
         </div>
-    </header>
+    </div>
 );
 
-export default Header;
+export default SideNavigation;

--- a/src/components/common/search-bar/index.tsx
+++ b/src/components/common/search-bar/index.tsx
@@ -8,7 +8,9 @@ const SearchBar = () => (
     <Button variant="transparent">
         <MdOutlineSearch className="h-4 aspect-square" />
         {/* <Text variant="label" className="text-secondary"> Search </Text> */}
-        <Chip value="CTRL + K" />
+        <div> {/* className="hidden lg:flex" */}
+            <Chip value="CTRL + K" />
+        </div>
     </Button>
 );
 

--- a/src/components/common/search-bar/index.tsx
+++ b/src/components/common/search-bar/index.tsx
@@ -1,11 +1,16 @@
 import Card from "components/common/card";
 import Chip from "components/common/chip";
+import Text from "../text";
+
+import { MdOutlineSearch } from "react-icons/md";
 
 const SearchBar = () => (
-    <Card className="flex flex-row gap-5 w-fit max-h-full px-5 py-3 !rounded-full cursor-pointer">
-        <p className="text-white/50 text-sm uppercase tracking-wide"> Search </p>
+    <Card className="flex flex-row items-center gap-5 w-fit max-h-full px-5 py-3 !rounded-full cursor-pointer">
+        <MdOutlineSearch className="h-4 aspect-square" />
+        <Text variant="label" className="text-secondary"> Search </Text>
         <Chip value="CTRL + K" />
     </Card>
 );
 
 export default SearchBar;
+4

--- a/src/components/common/search-bar/index.tsx
+++ b/src/components/common/search-bar/index.tsx
@@ -1,16 +1,15 @@
-import Card from "components/common/card";
+import Button from "../button";
 import Chip from "components/common/chip";
 import Text from "../text";
 
 import { MdOutlineSearch } from "react-icons/md";
 
 const SearchBar = () => (
-    <Card className="flex flex-row items-center gap-5 w-fit max-h-full px-5 py-3 !rounded-full cursor-pointer">
+    <Button variant="transparent">
         <MdOutlineSearch className="h-4 aspect-square" />
-        <Text variant="label" className="text-secondary"> Search </Text>
+        {/* <Text variant="label" className="text-secondary"> Search </Text> */}
         <Chip value="CTRL + K" />
-    </Card>
+    </Button>
 );
 
 export default SearchBar;
-4

--- a/src/components/common/text/index.tsx
+++ b/src/components/common/text/index.tsx
@@ -10,6 +10,7 @@ type TextProps = {
         | 'big-heading'
         | 'heading'
         | 'sub-heading'
+        | 'nav-heading'
         | 'paragraph'
         | 'input'
         | 'label';
@@ -25,6 +26,7 @@ const variants = {
     'big-heading': 'text-4xl font-medium md:text-6xl',
     heading: 'text-3xl font-medium',
     'sub-heading': 'text-2xl font-medium',
+    'nav-heading': 'text-xl font-medium',
     paragraph: 'text-lg',
     input: 'text-sm uppercase tracking-wide',
     label: 'text-xs uppercase',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -31,6 +31,7 @@ module.exports = {
             },
             borderWidth: {
                 '1.5': '1.5px',
+                '3': '3px',
             },
             screens: {
                 '2lg': '1111px',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,6 +20,7 @@ module.exports = {
                 neutral: '#1B1817',
                 base: '#26262B',
                 'base-content': '#ffffff',
+                line: '#666666',
                 
             },
             textColor: {
@@ -27,6 +28,9 @@ module.exports = {
             },
             width: {
                 '98': '28rem',
+            },
+            borderWidth: {
+                '1.5': '1.5px',
             },
             screens: {
                 '2lg': '1111px',


### PR DESCRIPTION
# Overview

Make design changes to `Header`, add navigation state indicators.

## Features

- Merge `Log In`- and `Sign Up`-buttons.
- Improve responsiveness - add better "overflow menu"-button.
   - Make `SearchBar` smaller - remove text.
   > Includes changes to `Button`-component.
   > Note:
      Overflow menu not yet created - navigation currently non-existent on smaller-width devices.
- Make `SearchBar` a button to ensure it's clear it should be pressed.
   > Includes changes to `Button`-component.
- Add state indicators to navigation links.
   > Includes changes to `Text`-component.

# Screenshots
## Desktop
|                                                      Before                                                     |                                                      After                                                      |
|:---------------------------------------------------------------------------------------------------------------:|:---------------------------------------------------------------------------------------------------------------:|
| ![image](https://user-images.githubusercontent.com/14112766/179066604-c4d83744-89aa-44f0-98af-6c07fd21af4a.png) | ![image](https://user-images.githubusercontent.com/14112766/179066642-a7e7002e-bdb0-4aed-89ce-55ba25045bbc.png) |

## Mobile
|                                                      Before                                                     |                                                      After                                                      |
|:---------------------------------------------------------------------------------------------------------------:|:---------------------------------------------------------------------------------------------------------------:|
| ![image](https://user-images.githubusercontent.com/14112766/179067179-6ac8803a-a666-4f36-8b3c-3a8a8a46e4f3.png) | ![image](https://user-images.githubusercontent.com/14112766/179066836-0822b063-0cba-434b-9b21-09da77d86e50.png) |