### PR TITLE
Add `createdAt` attribute to Bounties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "@solana/wallet-adapter-react-ui": "^0.9.5",
                 "@solana/wallet-adapter-wallets": "^0.15.3",
                 "@solana/web3.js": "^1.31.0",
+                "date-fns": "^2.28.0",
                 "next": "^12.1.6",
                 "next-compose-plugins": "^2.2.1",
                 "next-transpile-modules": "^9.0.0",
@@ -2301,6 +2302,18 @@
             "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
             "dev": true,
             "license": "BSD-2-Clause"
+        },
+        "node_modules/date-fns": {
+            "version": "2.28.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+            "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+            "engines": {
+                "node": ">=0.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/date-fns"
+            }
         },
         "node_modules/debug": {
             "version": "4.3.4",
@@ -7722,6 +7735,11 @@
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
             "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
             "dev": true
+        },
+        "date-fns": {
+            "version": "2.28.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+            "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
         },
         "debug": {
             "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "@solana/wallet-adapter-react-ui": "^0.9.5",
         "@solana/wallet-adapter-wallets": "^0.15.3",
         "@solana/web3.js": "^1.31.0",
+        "date-fns": "^2.28.0",
         "next": "^12.1.6",
         "next-compose-plugins": "^2.2.1",
         "next-transpile-modules": "^9.0.0",

--- a/src/components/explorer-page/bounty-card/index.tsx
+++ b/src/components/explorer-page/bounty-card/index.tsx
@@ -1,5 +1,6 @@
 import { cn, numberToCurrencyString } from 'utils';
 
+import { Bounty } from 'types/bounty';
 import Card from 'components/common/card';
 import Chip from 'components/common/chip';
 import Text from 'components/common/text';
@@ -9,18 +10,17 @@ const max = 5;
 /**
  * Properties for a "Featured Bounty" card component.
  */
-type FeaturedCardProps = {
-    name: string;
-    reward: number;
+type FeaturedCardProps = Omit<Bounty, 'tags'> & {
+    responsive?: boolean;
     tags: Array<{
         highlightValue?: string;
         value?: string;
         reversed?: boolean;
     }>;
-    responsive?: boolean;
 };
 
 const FeaturedBountyCard = ({
+    createdAt,
     name,
     reward,
     tags,
@@ -35,8 +35,11 @@ const FeaturedBountyCard = ({
         <div className="flex w-full max-w-full flex-row items-center gap-3">
             <div className="aspect-square h-16 w-16 rounded-lg bg-white" />
             <div className="flex flex-col overflow-hidden">
-                <Chip value="placed" highlightValue="11 Jul" reversed={true} />{' '}
-                {/* TODO: Add prop to make date customizable. */}
+                <Chip
+                    value="placed"
+                    highlightValue={createdAt}
+                    reversed={true}
+                />
                 <Text
                     variant="heading"
                     className={cn(
@@ -79,7 +82,7 @@ const FeaturedBountyCard = ({
                 <Text
                     variant="label"
                     className={cn(
-                        'text-secondary inline w-fit',
+                        'inline w-fit text-secondary',
                         responsive && '2lg:hidden',
                     )}
                 >

--- a/src/components/explorer-page/featured-section/index.tsx
+++ b/src/components/explorer-page/featured-section/index.tsx
@@ -1,5 +1,6 @@
 import FeaturedBountyCard from '../bounty-card';
 import Text from 'components/common/text';
+import { mockBounties } from 'mocks/bounties';
 
 const FeaturedSection = () => (
     <section
@@ -9,32 +10,13 @@ const FeaturedSection = () => (
         <Text variant="label">Featured</Text>
         <Text variant="big-heading">Popular Bounties</Text>
         <div className="flex w-full flex-row justify-start gap-5 overflow-x-auto scroll-smooth">
-            <FeaturedBountyCard
-                name="Really long bounty name"
-                reward={300}
-                tags={[
-                    { value: 'landing-page' },
-                    { value: 'enhancement' },
-                    { value: 'explorer-page' },
-                    { value: 'bug' },
-                    { value: 'explorer-page' },
-                    { value: 'explorer-page' },
-                    { value: 'explorer-page' },
-                ]}
-                responsive={false}
-            />
-
-            <FeaturedBountyCard
-                name="Really long bounty name"
-                reward={10_000_000}
-                tags={[
-                    { value: 'landing-page' },
-                    { value: 'bug' },
-                    { value: 'explorer-page' },
-                    { value: 'enhancement' },
-                ]}
-                responsive={false}
-            />
+            {mockBounties.map((bounty, index) => (
+                <FeaturedBountyCard
+                    key={index}
+                    responsive={false}
+                    {...bounty}
+                />
+            ))}
         </div>
     </section>
 );

--- a/src/mocks/bounties.ts
+++ b/src/mocks/bounties.ts
@@ -2,6 +2,7 @@ import { Bounty } from 'types/bounty';
 
 export const mockBounties: Bounty[] = [
     {
+        createdAt: '01 Jan',
         name: 'Really long bounty name',
         reward: 300,
         tags: [
@@ -15,6 +16,7 @@ export const mockBounties: Bounty[] = [
         ],
     },
     {
+        createdAt: '01 Jan',
         name: 'Really long bounty name',
         reward: 1_000_000,
         tags: [
@@ -28,6 +30,7 @@ export const mockBounties: Bounty[] = [
         ],
     },
     {
+        createdAt: '01 Jan',
         name: 'Really long bounty name',
         reward: 57,
         tags: [
@@ -41,6 +44,7 @@ export const mockBounties: Bounty[] = [
         ],
     },
     {
+        createdAt: '01 Jan',
         name: 'Really long bounty name',
         reward: 300,
         tags: [

--- a/src/types/bounty.ts
+++ b/src/types/bounty.ts
@@ -1,4 +1,5 @@
 export type Bounty = {
+    createdAt: string;
     name: string;
     reward: number;
     tags: { value: string }[];

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 import { Bounty } from 'types/bounty';
+import { format } from 'date-fns';
 
 // Concatenates classes into a single className string
 const cn = (...args: string[]) => args.join(' ');
@@ -16,6 +17,8 @@ const filterBounties = ({ name }: Bounty, rawQuery: string) => {
     return unformat(name).includes(query);
 };
 
+const formatDate = (date: string) => format(new Date(date), 'dd MMM');
+
 /**
  * Formats number as currency string.
  *
@@ -24,4 +27,4 @@ const filterBounties = ({ name }: Bounty, rawQuery: string) => {
 const numberToCurrencyString = (number: number) =>
     number.toLocaleString('en-US');
 
-export { cn, filterBounties, numberToCurrencyString };
+export { cn, filterBounties, formatDate, numberToCurrencyString };

--- a/yarn.lock
+++ b/yarn.lock
@@ -174,9 +174,9 @@
   dependencies:
     "glob" "7.1.7"
 
-"@next/swc-win32-x64-msvc@12.1.6":
-  "integrity" "sha512-4ZEwiRuZEicXhXqmhw3+de8Z4EpOLQj/gp+D9fFWo6ii6W1kBkNNvvEx4A90ugppu+74pT1lIJnOuz3A9oQeJA=="
-  "resolved" "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.1.6.tgz"
+"@next/swc-darwin-x64@12.1.6":
+  "integrity" "sha512-9FptMnbgHJK3dRDzfTpexs9S2hGpzOQxSQbe8omz6Pcl7rnEp9x4uSEKY51ho85JCjL4d0tDLBcXEJZKKLzxNg=="
+  "resolved" "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.1.6.tgz"
   "version" "12.1.6"
 
 "@nodelib/fs.scandir@2.1.5":
@@ -1294,6 +1294,11 @@
   "resolved" "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz"
   "version" "1.0.8"
 
+"date-fns@^2.28.0":
+  "integrity" "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
+  "resolved" "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz"
+  "version" "2.28.0"
+
 "debug@^2.6.9":
   "integrity" "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
   "resolved" "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
@@ -1942,6 +1947,11 @@
   "integrity" "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
+
+"fsevents@~2.3.2":
+  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
+  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  "version" "2.3.2"
 
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="


### PR DESCRIPTION
# Add `createdAt` attribute to Bounties

## Description

* 30d008d, 69cc428 - Added a `createdAt` attribute to the `Bounty` type and updated mock Bounties to follow the new schema.
* 242b5f0 - Updated the `BountyCard` to receive the above attribute via props.
* 4fb5142 - Installed [date-fns](https://date-fns.org/).
* 41d3c19 - Created a utility function (`formatDate()`) to parse date strings into the format expected by the updated `BountyCard`.
* 850f9d1 - Updated the `FeaturedSection` so that Bounties are dynamically rendered from mock data instead of being fixed.