### PR TITLE
Fix `BountyList` filtering bug; make `BountyCard` clickable

### DIFF
--- a/src/components/common/bounty-list/index.tsx
+++ b/src/components/common/bounty-list/index.tsx
@@ -4,7 +4,7 @@ import { Bounty } from 'types/bounty';
 import BountyCard from 'components/explorer-page/bounty-card';
 import FilterMenu from 'components/common/filter-section';
 import Text from '../text';
-import { filterBounties } from 'utils';
+import { filterBounties } from 'utils/bounties';
 
 type BountyListProps = { bounties: Bounty[] };
 
@@ -38,8 +38,8 @@ const BountyList = ({ bounties: initialBounties }: BountyListProps) => {
             </div>
             <div className="flex flex-col gap-6">
                 {bounties.length ? (
-                    bounties.map((bounty, index) => (
-                        <BountyCard key={index} {...bounty} />
+                    bounties.map(bounty => (
+                        <BountyCard key={bounty.id} {...bounty} />
                     ))
                 ) : (
                     <div className="flex h-20 items-center justify-center">

--- a/src/components/explorer-page/bounty-card/index.tsx
+++ b/src/components/explorer-page/bounty-card/index.tsx
@@ -3,12 +3,13 @@ import { cn, numberToCurrencyString } from 'utils';
 import { Bounty } from 'types/bounty';
 import Card from 'components/common/card';
 import Chip from 'components/common/chip';
+import Link from 'next/link';
 import Text from 'components/common/text';
 
 /**
  * Properties for a "Featured Bounty" card component.
  */
-type BountyCardProps = Omit<Bounty, 'tags'> & {
+type BountyCardProps = Omit<Bounty, 'githubUrl' | 'tags'> & {
     responsive?: boolean;
     maxTags?: number;
     showDetails?: boolean;
@@ -23,6 +24,7 @@ type BountyCardProps = Omit<Bounty, 'tags'> & {
 // TODO: Add owner and hunter props.
 const BountyCard = ({
     createdAt,
+    id,
     name,
     reward,
     tags,
@@ -30,120 +32,165 @@ const BountyCard = ({
     maxTags = 5,
     showDetails = false,
 }: BountyCardProps) => (
-    <Card
-        className={cn(
-            'flex h-fit w-98 flex-shrink-0 flex-col items-start justify-between gap-5 p-6',
-            responsive && '!w-full 2lg:flex-row 2lg:items-center',
-        )}
-    >
-        <div 
-            className={cn(
-                "flex w-full max-w-full flex-row gap-5",
-                !showDetails && "items-center"
-            )}
-        >
-            <div className="aspect-square h-[4.625rem] rounded-lg bg-white" />
-            <div className="flex flex-col gap-1 h-full overflow-hidden">
-                {!showDetails && (
-                    <>
-                        <Chip
-                            value="placed"
-                            highlightValue={createdAt}
-                            reversed={true} />
+    <Link href={`/explorer/${id}`} passHref>
+        <a>
+            <Card
+                className={cn(
+                    'flex h-fit w-98 flex-shrink-0 flex-col items-start justify-between gap-5 p-6 hover:bg-base',
+                    responsive && '!w-full 2lg:flex-row 2lg:items-center',
+                )}
+            >
+                <div
+                    className={cn(
+                        'flex w-full max-w-full flex-row gap-5',
+                        !showDetails && 'items-center',
+                    )}
+                >
+                    <div className="aspect-square h-[4.625rem] rounded-lg bg-white" />
+                    <div className="flex h-full flex-col gap-1 overflow-hidden">
+                        {!showDetails && (
+                            <>
+                                <Chip
+                                    value="placed"
+                                    highlightValue={createdAt}
+                                    reversed={true}
+                                />
+                                <Text
+                                    variant="heading"
+                                    className={cn(
+                                        'inline w-full overflow-hidden text-ellipsis whitespace-nowrap',
+                                        responsive && '2lg:hidden',
+                                    )}
+                                >
+                                    {name}
+                                </Text>
+                            </>
+                        )}
+                        {showDetails && (
+                            <div className="flex h-full flex-row gap-7">
+                                <div className="flex flex-col gap-3">
+                                    <Text
+                                        variant="label"
+                                        className="text-secondary"
+                                    >
+                                        Owner
+                                    </Text>
+                                    <div className="flex flex-row items-center gap-3">
+                                        <div className="aspect-square h-10 rounded-full bg-white" />
+                                        <Text
+                                            variant="user"
+                                            className="hidden sm:inline"
+                                        >
+                                            JohnDoe
+                                        </Text>
+                                        <Text
+                                            variant="label"
+                                            className="text-primary"
+                                        >
+                                            Lv. 1
+                                        </Text>
+                                    </div>
+                                </div>
+                                <div className="flex flex-col gap-3">
+                                    <Text
+                                        variant="label"
+                                        className="text-secondary"
+                                    >
+                                        Hunter
+                                    </Text>
+                                    <div className="flex flex-row items-center gap-3">
+                                        <div className="aspect-square h-10 rounded-full bg-white" />
+                                        <Text
+                                            variant="user"
+                                            className="hidden sm:inline"
+                                        >
+                                            JohnDoe
+                                        </Text>
+                                        <Text
+                                            variant="label"
+                                            className="text-primary"
+                                        >
+                                            Lv. 1
+                                        </Text>
+                                    </div>
+                                </div>
+                            </div>
+                        )}
                         <Text
-                            variant="heading"
+                            variant="sub-heading"
                             className={cn(
-                                'inline w-full overflow-hidden text-ellipsis whitespace-nowrap',
-                                responsive && '2lg:hidden'
+                                'hidden w-full overflow-hidden text-ellipsis whitespace-nowrap',
+                                responsive && '2lg:inline',
                             )}
                         >
                             {name}
                         </Text>
-                    </>
-                )}
-                {showDetails && (
-                    <div className="flex flex-row gap-7 h-full">
-                        <div className="flex flex-col gap-3">
-                            <Text variant="label" className="text-secondary"> Owner </Text>
-                            <div className="flex flex-row items-center gap-3">
-                                <div className="aspect-square h-10 rounded-full bg-white" />
-                                <Text variant="user" className="hidden sm:inline"> JohnDoe </Text>
-                                <Text variant="label" className="text-primary"> Lv. 1 </Text>
-                            </div>
-                        </div>
-                        <div className="flex flex-col gap-3">
-                            <Text variant="label" className="text-secondary"> Hunter </Text>
-                            <div className="flex flex-row items-center gap-3">
-                                <div className="aspect-square h-10 rounded-full bg-white" />
-                                <Text variant="user" className="hidden sm:inline"> JohnDoe </Text>
-                                <Text variant="label" className="text-primary"> Lv. 1 </Text>
-                            </div>
+                    </div>
+                </div>
+                <div
+                    className={cn(
+                        'flex w-full flex-row items-start gap-5',
+                        !showDetails && '2lg:items-center',
+                    )}
+                >
+                    <div className="flex h-full w-40 flex-col gap-1 overflow-hidden">
+                        <Text
+                            variant="label"
+                            className={cn(
+                                'inline text-secondary',
+                                responsive && !showDetails && '2lg:hidden',
+                            )}
+                        >
+                            Reward{!showDetails && '· SOL'}
+                        </Text>
+                        <Text
+                            variant="heading"
+                            className="flex max-w-full flex-row items-center gap-2 overflow-hidden text-ellipsis whitespace-nowrap text-primary"
+                        >
+                            {numberToCurrencyString(reward)}{' '}
+                            {showDetails && (
+                                <Text
+                                    variant="paragraph"
+                                    className="font-extralight uppercase text-white"
+                                >
+                                    SOL
+                                </Text>
+                            )}
+                        </Text>
+                    </div>
+                    <div className="flex w-full flex-col items-end gap-1">
+                        <Text
+                            variant="label"
+                            className={cn(
+                                'inline w-fit text-secondary',
+                                responsive && !showDetails && '2lg:hidden',
+                            )}
+                        >
+                            Tags
+                        </Text>
+                        <div className="flex w-full flex-row flex-wrap items-end justify-end gap-1.5">
+                            {tags
+                                .slice(0, maxTags)
+                                .map(({ value, highlightValue, reversed }) => (
+                                    <Chip
+                                        key={value}
+                                        highlightValue={highlightValue}
+                                        value={value}
+                                        reversed={reversed}
+                                        className="max-w-[4.25rem]"
+                                    />
+                                ))}
+                            {tags.length > maxTags && (
+                                <Chip
+                                    highlightValue={`+${tags.length - maxTags}`}
+                                />
+                            )}
                         </div>
                     </div>
-                )}
-                <Text
-                    variant="sub-heading"
-                    className={cn(
-                        'hidden w-full overflow-hidden text-ellipsis whitespace-nowrap',
-                        responsive && '2lg:inline',
-                    )}
-                >
-                    {name}
-                </Text>
-            </div>
-        </div>
-        <div 
-            className={cn(
-                "flex w-full flex-row items-start gap-5",
-                !showDetails && "2lg:items-center"
-            )}
-        >
-            <div className="flex h-full w-40 flex-col gap-1 overflow-hidden">
-                <Text
-                    variant="label"
-                    className={cn(
-                        'inline text-secondary',
-                        (responsive && !showDetails) && '2lg:hidden',
-                    )}
-                >
-                    Reward{!showDetails && "· SOL"}
-                </Text>
-                <Text
-                    variant="heading"
-                    className="flex flex-row items-center gap-2 max-w-full overflow-hidden text-ellipsis whitespace-nowrap text-primary"
-                >
-                    {numberToCurrencyString(reward)} {showDetails && <Text variant="paragraph" className="font-extralight uppercase text-white"> SOL </Text>}
-                </Text>
-            </div>
-            <div className="flex w-full flex-col items-end gap-1">
-                <Text
-                    variant="label"
-                    className={cn(
-                        'inline w-fit text-secondary',
-                        (responsive && !showDetails) && '2lg:hidden',
-                    )}
-                >
-                    Tags
-                </Text>
-                <div className="flex w-full flex-row flex-wrap items-end justify-end gap-1.5">
-                    {tags
-                        .slice(0, maxTags)
-                        .map(({ value, highlightValue, reversed }) => (
-                            <Chip
-                                key={value}
-                                highlightValue={highlightValue}
-                                value={value}
-                                reversed={reversed}
-                                className="max-w-[4.25rem]"
-                            />
-                        ))}
-                    {tags.length > maxTags && (
-                        <Chip highlightValue={`+${tags.length - maxTags}`} />
-                    )}
                 </div>
-            </div>
-        </div>
-    </Card>
+            </Card>
+        </a>
+    </Link>
 );
 
 export default BountyCard;

--- a/src/components/explorer-page/featured-section/index.tsx
+++ b/src/components/explorer-page/featured-section/index.tsx
@@ -10,12 +10,8 @@ const FeaturedSection = () => (
         <Text variant="label">Featured</Text>
         <Text variant="big-heading">Popular Bounties</Text>
         <div className="flex w-full flex-row justify-start gap-5 overflow-x-auto scroll-smooth">
-            {mockBounties.map((bounty, index) => (
-                <BountyCard
-                    key={index}
-                    responsive={false}
-                    {...bounty}
-                />
+            {mockBounties.map(bounty => (
+                <BountyCard key={bounty.id} responsive={false} {...bounty} />
             ))}
         </div>
     </section>

--- a/src/mocks/bounties.ts
+++ b/src/mocks/bounties.ts
@@ -3,6 +3,8 @@ import { Bounty } from 'types/bounty';
 export const mockBounties: Bounty[] = [
     {
         createdAt: '01 Jan',
+        githubUrl: '',
+        id: 9999,
         name: 'Really long bounty name',
         reward: 300,
         tags: [
@@ -17,6 +19,8 @@ export const mockBounties: Bounty[] = [
     },
     {
         createdAt: '01 Jan',
+        githubUrl: '',
+        id: 9998,
         name: 'Really long bounty name',
         reward: 1_000_000,
         tags: [
@@ -31,6 +35,8 @@ export const mockBounties: Bounty[] = [
     },
     {
         createdAt: '01 Jan',
+        githubUrl: '',
+        id: 9997,
         name: 'Really long bounty name',
         reward: 57,
         tags: [
@@ -45,6 +51,8 @@ export const mockBounties: Bounty[] = [
     },
     {
         createdAt: '01 Jan',
+        githubUrl: '',
+        id: 9996,
         name: 'Really long bounty name',
         reward: 300,
         tags: [

--- a/src/pages/explorer/[bounty].tsx
+++ b/src/pages/explorer/[bounty].tsx
@@ -1,29 +1,51 @@
-import Button from 'components/common/button';
-import NavElement from 'components/common/layout/header/nav-element';
-import Text from 'components/common/text';
+import { MdChevronLeft, MdLink } from 'react-icons/md';
+
 import AboutSection from 'components/detail-page/about-section';
 import BountyCard from 'components/explorer-page/bounty-card';
+import Button from 'components/common/button';
+import Link from 'next/link';
+import NavElement from 'components/common/layout/header/nav-element';
 import { NextPage } from 'next';
+import Text from 'components/common/text';
 import { useRouter } from 'next/router';
-import { MdChevronLeft, MdLink } from 'react-icons/md';
 
 const BountyDetail: NextPage = () => {
     const tabs = [
-        {id: 'about', section: <AboutSection />, label: 'About'},
-        {id: 'fund', section: <div> <Text variant="big-heading"> Fund </Text> </div>, label: 'Fund'},
-        {id: 'details', section: <div> <Text variant="big-heading"> Details </Text> </div>, label: 'Details'},
+        { id: 'about', section: <AboutSection />, label: 'About' },
+        {
+            id: 'fund',
+            section: (
+                <div>
+                    <Text variant="big-heading"> Fund </Text>
+                </div>
+            ),
+            label: 'Fund',
+        },
+        {
+            id: 'details',
+            section: (
+                <div>
+                    <Text variant="big-heading"> Details </Text>
+                </div>
+            ),
+            label: 'Details',
+        },
     ];
 
     const router = useRouter();
     const { bounty } = router.query;
-    const currentTab = router.query.tab as string || tabs[0].id;
+    const currentTab = (router.query.tab as string) || tabs[0].id;
 
     return (
         <div className="flex flex-col gap-8 p-5 text-white sm:p-8 md:px-16 lg:px-32 lg:py-16 xl:px-48 xl:py-20">
-            <div className="flex flex-row justify-between items-center">
-                <Button text="Back" variant="label" reversed={true}>
-                    <MdChevronLeft className="aspect-square h-4" />
-                </Button>
+            <div className="flex flex-row items-center justify-between">
+                <Link href="/explorer" passHref>
+                    <a>
+                        <Button text="Back" variant="label" reversed={true}>
+                            <MdChevronLeft className="aspect-square h-4" />
+                        </Button>
+                    </a>
+                </Link>
 
                 <div className="flex flex-row gap-3">
                     <Button text="Claim" variant="orange" />
@@ -35,11 +57,29 @@ const BountyDetail: NextPage = () => {
 
             <Text variant="big-heading">{bounty}</Text>
 
-            <Text variant="nav-heading"> Basics </Text>
+            <Text variant="nav-heading">Basics</Text>
 
-            <BountyCard showDetails={true} maxTags={7} createdAt={"Jun 6"}name={''}reward={100}tags={[{value:"TypeScript"},{value:"React"},{value:"Next.js"},{value:"Node.js"},{value:"Express"},{value:"MongoDB"},{value:"GraphQL"},{value:"Apollo"},{value:"Apollo Client"},]}/>
+            <BountyCard
+                id={parseInt(bounty as string)}
+                showDetails={true}
+                maxTags={7}
+                createdAt={'Jun 6'}
+                name={''}
+                reward={100}
+                tags={[
+                    { value: 'TypeScript' },
+                    { value: 'React' },
+                    { value: 'Next.js' },
+                    { value: 'Node.js' },
+                    { value: 'Express' },
+                    { value: 'MongoDB' },
+                    { value: 'GraphQL' },
+                    { value: 'Apollo' },
+                    { value: 'Apollo Client' },
+                ]}
+            />
 
-            <div className="sticky top-20 -mt-px flex h-16 pt-4 flex-row gap-8 bg-black border-b-1.5 border-b-line">
+            <div className="sticky top-20 -mt-px flex h-16 flex-row gap-8 border-b-1.5 border-b-line bg-black pt-4">
                 {tabs.map((tab, index) => (
                     <NavElement
                         key={tab.id}

--- a/src/types/bounty.ts
+++ b/src/types/bounty.ts
@@ -1,5 +1,7 @@
 export type Bounty = {
     createdAt: string;
+    githubUrl: string;
+    id: number;
     name: string;
     reward: number;
     tags: { value: string }[];

--- a/src/utils/bounties.ts
+++ b/src/utils/bounties.ts
@@ -26,11 +26,13 @@ const toBountyList = (issues: Issue[]): Bounty[] =>
     issues.map(
         ({
             created_at: createdAt,
+            number,
             labels,
             title: name,
             html_url: githubUrl,
         }) => ({
             createdAt: formatDate(createdAt),
+            id: number,
             githubUrl,
             name,
             reward: 0,


### PR DESCRIPTION
# Fix `BountyList` filtering bug; make `BountyCard` clickable

## Related tasks

N/A

## Description

- Fixed a bug where the app would crash when filtering bounties in the `BountyList` component. This was due to a change in the import path.
- Added an `id` attribute to bounties mapping to GitHub issue numbers.
- The `BountyCard` is now clickable, allowing redirection to the `/explorer/[bounty]` path.

## Demo

![Screen Recording 2022-08-01 at 11 36 11](https://user-images.githubusercontent.com/36577958/182199668-4df1f972-0f7d-4ba2-9cfa-a2eff4ad947a.gif)