### PR TITLE
Added Min Height to `stats-section`

### DIFF
--- a/src/components/home-page/stats-section/index.tsx
+++ b/src/components/home-page/stats-section/index.tsx
@@ -34,7 +34,7 @@ const statItems = [
 const StatsSection = () => (
     <section
         title="faq"
-        className="grid text-black sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-4"
+        className="grid min-h-[70px] text-black sm:grid-cols-1 md:grid-cols-2  lg:grid-cols-4"
     >
         {statItems.map(
             ({


### PR DESCRIPTION
Added min height to stats section to prevent it from being too thin on desktop view.

# Screenshot
<img width="1265" alt="Screenshot 2022-08-04 110105" src="https://user-images.githubusercontent.com/73449575/182880968-e8331641-8537-46e2-aa7e-9b48779f3e89.png">
